### PR TITLE
Add before and after gallery section

### DIFF
--- a/public/images/bathroom-after.svg
+++ b/public/images/bathroom-after.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <defs>
+    <linearGradient id="bath-clean-bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f7fdff" />
+      <stop offset="100%" stop-color="#dff5ff" />
+    </linearGradient>
+    <linearGradient id="bath-tiles" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#eaf8ff" />
+      <stop offset="100%" stop-color="#cfe5ff" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#bath-clean-bg)" />
+  <g>
+    <rect x="120" y="80" width="560" height="360" rx="20" fill="url(#bath-tiles)" stroke="#bcdfff" stroke-width="6" />
+    <g fill="#ffffff" opacity="0.85">
+      <rect x="160" y="140" width="80" height="220" rx="16" />
+      <rect x="300" y="150" width="200" height="140" rx="16" />
+      <rect x="540" y="160" width="100" height="200" rx="16" />
+    </g>
+  </g>
+  <g stroke="#8cd5ff" stroke-width="10" stroke-linecap="round" opacity="0.75">
+    <line x1="180" y1="360" x2="220" y2="320" />
+    <line x1="320" y1="360" x2="360" y2="320" />
+    <line x1="460" y1="360" x2="500" y2="320" />
+    <line x1="600" y1="360" x2="640" y2="320" />
+  </g>
+  <g fill="#9adff8" opacity="0.7">
+    <circle cx="200" cy="220" r="12" />
+    <circle cx="260" cy="200" r="10" />
+    <circle cx="360" cy="240" r="12" />
+    <circle cx="460" cy="210" r="14" />
+    <circle cx="600" cy="230" r="11" />
+  </g>
+  <text x="50%" y="70" font-family="'Poppins', sans-serif" font-size="48" fill="#1f6896" text-anchor="middle">Después - Baño</text>
+  <text x="50%" y="520" font-family="'Poppins', sans-serif" font-size="26" fill="#1c5680" text-anchor="middle">Azulejos brillantes y cristales sin marcas.</text>
+</svg>

--- a/public/images/bathroom-before.svg
+++ b/public/images/bathroom-before.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <defs>
+    <linearGradient id="bath-bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#fce9d6" />
+      <stop offset="100%" stop-color="#f5cfa1" />
+    </linearGradient>
+    <linearGradient id="tiles" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#d8d8d8" />
+      <stop offset="100%" stop-color="#b1b1b1" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#bath-bg)" />
+  <g opacity="0.7">
+    <rect x="120" y="80" width="560" height="360" fill="url(#tiles)" />
+    <g fill="#8b7461" opacity="0.8">
+      <rect x="160" y="140" width="80" height="220" />
+      <rect x="300" y="150" width="200" height="140" />
+      <rect x="540" y="160" width="100" height="200" />
+    </g>
+  </g>
+  <g fill="#6e4c2d" opacity="0.6">
+    <circle cx="210" cy="380" r="22" />
+    <circle cx="260" cy="340" r="18" />
+    <circle cx="360" cy="360" r="26" />
+    <circle cx="450" cy="330" r="20" />
+    <circle cx="600" cy="320" r="18" />
+  </g>
+  <g opacity="0.5" fill="#47311d">
+    <path d="M190 120h40l-16 28h-28z" />
+    <path d="M330 110h80l-24 40h-70z" />
+    <path d="M520 130h60l-18 32h-50z" />
+  </g>
+  <text x="50%" y="70" font-family="'Poppins', sans-serif" font-size="48" fill="#654021" text-anchor="middle">Antes - Baño</text>
+  <text x="50%" y="520" font-family="'Poppins', sans-serif" font-size="26" fill="#5b3416" text-anchor="middle">Azulejos con sarro y cristales empañados.</text>
+</svg>

--- a/public/images/kitchen-after.svg
+++ b/public/images/kitchen-after.svg
@@ -1,0 +1,42 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f4fbff" />
+      <stop offset="100%" stop-color="#d5f0ff" />
+    </linearGradient>
+    <linearGradient id="counter" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#f0f6ff" />
+      <stop offset="100%" stop-color="#c2dfff" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#bg)" />
+  <g opacity="0.95">
+    <rect x="80" y="120" width="640" height="200" rx="18" fill="#ffffff" stroke="#c8e6ff" stroke-width="6" />
+    <rect x="120" y="160" width="120" height="140" rx="12" fill="#f6fcff" stroke="#cfe8ff" stroke-width="4" />
+    <rect x="280" y="160" width="160" height="140" rx="12" fill="#f4fbff" stroke="#cfe8ff" stroke-width="4" />
+    <rect x="480" y="160" width="200" height="140" rx="12" fill="#f6fcff" stroke="#cfe8ff" stroke-width="4" />
+  </g>
+  <rect x="80" y="320" width="640" height="140" rx="16" fill="url(#counter)" stroke="#b7d4ff" stroke-width="5" />
+  <g>
+    <path d="M150 350h120v32h-120z" fill="#ffffff" opacity="0.75" />
+    <path d="M320 350h120v32h-120z" fill="#ffffff" opacity="0.75" />
+    <path d="M500 350h160v32h-160z" fill="#ffffff" opacity="0.75" />
+  </g>
+  <g fill="#68c3ff" opacity="0.7">
+    <circle cx="160" cy="230" r="12" />
+    <circle cx="220" cy="210" r="10" />
+    <circle cx="320" cy="240" r="14" />
+    <circle cx="420" cy="200" r="12" />
+    <circle cx="520" cy="245" r="16" />
+    <circle cx="640" cy="215" r="11" />
+  </g>
+  <g stroke="#9adcfb" stroke-width="8" stroke-linecap="round" opacity="0.7">
+    <line x1="180" y1="440" x2="220" y2="400" />
+    <line x1="280" y1="440" x2="320" y2="400" />
+    <line x1="380" y1="440" x2="420" y2="400" />
+    <line x1="480" y1="440" x2="520" y2="400" />
+    <line x1="580" y1="440" x2="620" y2="400" />
+  </g>
+  <text x="50%" y="70" font-family="'Poppins', sans-serif" font-size="48" fill="#1f5d95" text-anchor="middle">Después - Cocina</text>
+  <text x="50%" y="520" font-family="'Poppins', sans-serif" font-size="26" fill="#1c4f7a" text-anchor="middle">Superficies relucientes, desinfectadas y organizadas.</text>
+</svg>

--- a/public/images/kitchen-before.svg
+++ b/public/images/kitchen-before.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <defs>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f9caca" />
+      <stop offset="100%" stop-color="#f3a7a7" />
+    </linearGradient>
+    <linearGradient id="counter" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#b26a42" />
+      <stop offset="100%" stop-color="#8c4d2c" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#bg)" />
+  <g opacity="0.65">
+    <rect x="80" y="120" width="640" height="200" fill="#d0d0d0" />
+    <rect x="120" y="160" width="120" height="140" fill="#bbb" />
+    <rect x="280" y="160" width="160" height="140" fill="#c2c2c2" />
+    <rect x="480" y="160" width="200" height="140" fill="#b5b5b5" />
+  </g>
+  <rect x="80" y="320" width="640" height="140" fill="url(#counter)" />
+  <g fill="#813c3c" opacity="0.6">
+    <circle cx="150" cy="360" r="26" />
+    <circle cx="220" cy="390" r="18" />
+    <circle cx="320" cy="350" r="30" />
+    <circle cx="420" cy="410" r="24" />
+    <circle cx="520" cy="355" r="22" />
+    <circle cx="610" cy="385" r="18" />
+    <circle cx="690" cy="360" r="16" />
+  </g>
+  <g opacity="0.35" fill="#4c2f2f">
+    <path d="M160 220h80l-20 40h-60z" />
+    <path d="M340 210h100l-30 60h-90z" />
+    <path d="M520 230h120l-40 70h-110z" />
+  </g>
+  <text x="50%" y="70" font-family="'Poppins', sans-serif" font-size="48" fill="#702525" text-anchor="middle">Antes - Cocina</text>
+  <text x="50%" y="520" font-family="'Poppins', sans-serif" font-size="26" fill="#5a1a1a" text-anchor="middle">Superficies con grasa, salpicaduras y residuos visibles.</text>
+</svg>

--- a/public/images/livingroom-after.svg
+++ b/public/images/livingroom-after.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <defs>
+    <linearGradient id="living-clean-bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f9f6ff" />
+      <stop offset="100%" stop-color="#e6ddff" />
+    </linearGradient>
+    <linearGradient id="sofa" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" />
+      <stop offset="100%" stop-color="#e8e0ff" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#living-clean-bg)" />
+  <g opacity="0.95">
+    <rect x="120" y="220" width="560" height="180" rx="40" fill="url(#sofa)" stroke="#d1c5ff" stroke-width="6" />
+    <rect x="140" y="160" width="200" height="120" rx="30" fill="#ffffff" stroke="#d7ccff" stroke-width="4" />
+    <rect x="380" y="150" width="240" height="130" rx="30" fill="#ffffff" stroke="#d7ccff" stroke-width="4" />
+  </g>
+  <g fill="#c4b5ff" opacity="0.7">
+    <circle cx="200" cy="260" r="12" />
+    <circle cx="260" cy="220" r="10" />
+    <circle cx="360" cy="260" r="12" />
+    <circle cx="460" cy="230" r="10" />
+    <circle cx="560" cy="260" r="12" />
+    <circle cx="640" cy="220" r="10" />
+  </g>
+  <g stroke="#d0c4ff" stroke-width="10" stroke-linecap="round" opacity="0.7">
+    <line x1="160" y1="360" x2="210" y2="320" />
+    <line x1="300" y1="360" x2="350" y2="320" />
+    <line x1="440" y1="360" x2="490" y2="320" />
+    <line x1="580" y1="360" x2="630" y2="320" />
+  </g>
+  <text x="50%" y="90" font-family="'Poppins', sans-serif" font-size="48" fill="#4a388b" text-anchor="middle">Después - Sala</text>
+  <text x="50%" y="520" font-family="'Poppins', sans-serif" font-size="26" fill="#3f3175" text-anchor="middle">Ambiente fresco, ordenado y libre de polvo.</text>
+</svg>

--- a/public/images/livingroom-before.svg
+++ b/public/images/livingroom-before.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <defs>
+    <linearGradient id="living-bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f5e0ff" />
+      <stop offset="100%" stop-color="#dab7f3" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#living-bg)" />
+  <g opacity="0.7" fill="#b18bc9">
+    <rect x="120" y="220" width="560" height="180" rx="40" />
+    <rect x="140" y="160" width="200" height="120" rx="30" />
+    <rect x="380" y="150" width="240" height="130" rx="30" />
+  </g>
+  <g fill="#8e5f9f" opacity="0.7">
+    <circle cx="180" cy="260" r="24" />
+    <circle cx="240" cy="320" r="18" />
+    <circle cx="360" cy="300" r="28" />
+    <circle cx="460" cy="340" r="20" />
+    <circle cx="560" cy="310" r="18" />
+    <circle cx="640" cy="280" r="16" />
+  </g>
+  <g opacity="0.45" fill="#6f407f">
+    <path d="M160 190h120l-40 60h-100z" />
+    <path d="M360 180h160l-50 80h-140z" />
+  </g>
+  <text x="50%" y="90" font-family="'Poppins', sans-serif" font-size="48" fill="#6c3a87" text-anchor="middle">Antes - Sala</text>
+  <text x="50%" y="520" font-family="'Poppins', sans-serif" font-size="26" fill="#5a2f71" text-anchor="middle">Polvo en tapicería y manchas visibles en la alfombra.</text>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Navigation } from "./components/navigation";
 import { HeroSection } from "./components/hero-section";
 import { ServicesSection } from "./components/services-section";
 import { BenefitsSection } from "./components/benefits-section";
+import { BeforeAfterSection } from "./components/before-after-section";
 import { TestimonialsSection } from "./components/testimonials-section";
 import { ProcessSection } from "./components/process-section";
 import { ContactSection } from "./components/contact-section";
@@ -21,6 +22,9 @@ export default function App() {
         </div>
         <div id="benefits">
           <BenefitsSection />
+        </div>
+        <div id="results">
+          <BeforeAfterSection />
         </div>
         <div id="testimonials">
           <TestimonialsSection />

--- a/src/components/before-after-section.tsx
+++ b/src/components/before-after-section.tsx
@@ -1,0 +1,179 @@
+import { useState } from "react";
+import { motion } from "motion/react";
+import { ImageWithFallback } from "./figma/ImageWithFallback";
+import { Badge } from "./ui/badge";
+
+interface TransformationCase {
+  id: string;
+  title: string;
+  description: string;
+  before: string;
+  after: string;
+  duration: string;
+  focus: string;
+  results: string[];
+}
+
+const transformations: TransformationCase[] = [
+  {
+    id: "kitchen",
+    title: "Cocina Familiar",
+    description:
+      "Eliminamos grasa, residuos y olores persistentes para devolverle a la cocina un aspecto impecable y seguro para preparar alimentos.",
+    before: "/images/kitchen-before.svg",
+    after: "/images/kitchen-after.svg",
+    duration: "3 h",
+    focus: "Desengrasado profundo",
+    results: [
+      "Electrodomésticos desinfectados",
+      "Superficies sin grasa ni manchas",
+      "Organización de encimeras y utensilios",
+    ],
+  },
+  {
+    id: "bathroom",
+    title: "Baño Principal",
+    description:
+      "Removimos sarro y hongos de azulejos y cristales, dejando un baño fresco y desinfectado listo para el uso diario.",
+    before: "/images/bathroom-before.svg",
+    after: "/images/bathroom-after.svg",
+    duration: "2.5 h",
+    focus: "Desinfección de superficies",
+    results: [
+      "Mamparas transparentes",
+      "Azulejos brillantes",
+      "Ambiente libre de humedad",
+    ],
+  },
+  {
+    id: "livingroom",
+    title: "Sala de Estar",
+    description:
+      "Aspiramos, desinfectamos y organizamos cada rincón para lograr una sala acogedora, libre de polvo y lista para recibir visitas.",
+    before: "/images/livingroom-before.svg",
+    after: "/images/livingroom-after.svg",
+    duration: "2 h",
+    focus: "Cuidado de tapicería",
+    results: [
+      "Alfombra renovada",
+      "Tapicería sin manchas",
+      "Aroma fresco y agradable",
+    ],
+  },
+];
+
+export function BeforeAfterSection() {
+  return (
+    <section id="results" className="py-20 bg-gradient-to-b from-blue-50 via-white to-blue-50">
+      <div className="container mx-auto px-4">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          viewport={{ once: true }}
+          className="text-center max-w-3xl mx-auto mb-16"
+        >
+          <Badge className="mb-4 bg-blue-100 text-blue-700 border-blue-200">Resultados Reales</Badge>
+          <h2 className="text-4xl font-bold text-gray-800 mb-4">
+            Antes y Después de Nuestras Limpiezas
+          </h2>
+          <p className="text-lg text-gray-600">
+            Cada transformación refleja la dedicación de nuestro equipo y el cuidado con el que tratamos cada espacio.
+            Mueve el control para ver la diferencia completa.
+          </p>
+        </motion.div>
+
+        <div className="grid gap-10 lg:grid-cols-3">
+          {transformations.map((item, index) => (
+            <BeforeAfterCard key={item.id} data={item} index={index} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+interface BeforeAfterCardProps {
+  data: TransformationCase;
+  index: number;
+}
+
+function BeforeAfterCard({ data, index }: BeforeAfterCardProps) {
+  const [position, setPosition] = useState(55);
+  const sliderId = `before-after-slider-${data.id}`;
+
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 30 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6, delay: index * 0.1 }}
+      viewport={{ once: true }}
+      whileHover={{ y: -8 }}
+      className="bg-white rounded-3xl shadow-xl overflow-hidden flex flex-col"
+    >
+      <div className="relative h-80">
+        <ImageWithFallback
+          src={data.before}
+          alt={`Antes de la limpieza en ${data.title}`}
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+        <div
+          className="absolute inset-0 overflow-hidden"
+          style={{ clipPath: `inset(0 ${100 - position}% 0 0)` }}
+        >
+          <ImageWithFallback
+            src={data.after}
+            alt={`Después de la limpieza en ${data.title}`}
+            className="h-full w-full object-cover"
+          />
+        </div>
+        <div
+          className="absolute inset-y-0"
+          style={{ left: `${position}%` }}
+        >
+          <div className="h-full w-1 bg-white shadow-[0_0_20px_rgba(37,99,235,0.45)]" />
+        </div>
+        <div className="absolute top-4 left-4 bg-white/85 text-gray-800 px-3 py-1 rounded-full text-sm font-semibold">
+          Antes
+        </div>
+        <div className="absolute top-4 right-4 bg-blue-600 text-white px-3 py-1 rounded-full text-sm font-semibold">
+          Después
+        </div>
+        <input
+          id={sliderId}
+          type="range"
+          min={0}
+          max={100}
+          value={position}
+          onChange={(event) => setPosition(Number(event.target.value))}
+          className="absolute bottom-6 left-1/2 -translate-x-1/2 w-3/4 accent-blue-600 cursor-pointer"
+          aria-label={`Comparar el antes y después de ${data.title}`}
+        />
+      </div>
+
+      <div className="p-8 flex-1 flex flex-col">
+        <div className="flex items-center justify-between mb-4">
+          <Badge variant="outline" className="text-blue-600 border-blue-200 bg-blue-50">
+            {data.focus}
+          </Badge>
+          <Badge className="bg-blue-600 text-white border-blue-600">{data.duration}</Badge>
+        </div>
+        <h3 className="text-2xl font-semibold text-gray-800 mb-3">{data.title}</h3>
+        <p className="text-gray-600 mb-6 flex-1">{data.description}</p>
+        <div>
+          <p className="text-sm font-semibold text-gray-700 mb-3 uppercase tracking-wide">
+            Resultados Destacados
+          </p>
+          <ul className="space-y-2 text-gray-700">
+            {data.results.map((result) => (
+              <li key={result} className="flex items-center gap-3">
+                <span className="inline-block h-2 w-2 rounded-full bg-blue-500" />
+                {result}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </motion.article>
+  );
+}

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -49,14 +49,21 @@ export function Navigation() {
             >
               Servicios
             </a>
-            <a 
+            <a
               href="#"
               onClick={() => scrollToSection('benefits')}
               className="text-gray-700 hover:text-blue-600 transition-colors cursor-pointer"
             >
               Beneficios
             </a>
-            <a 
+            <a
+              href="#results"
+              onClick={() => scrollToSection('results')}
+              className="text-gray-700 hover:text-blue-600 transition-colors cursor-pointer"
+            >
+              Resultados
+            </a>
+            <a
               href="#"
               onClick={() => scrollToSection('testimonials')}
               className="text-gray-700 hover:text-blue-600 transition-colors cursor-pointer"
@@ -119,14 +126,21 @@ export function Navigation() {
               >
                 Servicios
               </a>
-              <a 
+              <a
                 href="#"
                 onClick={() => scrollToSection('benefits')}
                 className="block px-4 py-2 text-gray-700 hover:text-blue-600 hover:bg-blue-50 transition-colors cursor-pointer"
               >
                 Beneficios
               </a>
-              <a 
+              <a
+                href="#results"
+                onClick={() => scrollToSection('results')}
+                className="block px-4 py-2 text-gray-700 hover:text-blue-600 hover:bg-blue-50 transition-colors cursor-pointer"
+              >
+                Resultados
+              </a>
+              <a
                 href="#"
                 onClick={() => scrollToSection('testimonials')}
                 className="block px-4 py-2 text-gray-700 hover:text-blue-600 hover:bg-blue-50 transition-colors cursor-pointer"


### PR DESCRIPTION
## Summary
- add a before/after gallery component with slider interactions and transformation details for three cleaning cases
- wire the new section into the homepage navigation flow and layout
- include illustrative before and after assets for kitchen, bathroom, and living room scenes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4b57996a88331b50136793dd3a606